### PR TITLE
Feature/dte 575/GitHub action ecr codeartifact build

### DIFF
--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -1,0 +1,21 @@
+# Gets next git version tag, builds and deploys Docker image to ECR; if
+# successful, tags git with new version.
+on:
+  push:
+    branches:
+      - 'main'
+  # Enable manual run; must be in main branch to be available
+  workflow_dispatch:
+jobs:
+  ecr-build:
+    uses: nationalarchives/tre-github-actions/.github/workflows/docker-build-and-ecr-deploy.yml@0.0.3
+    with:
+      docker_image_name: 'tre-dlq-slack-alerts'
+      build_dir: 'tre-dlq-slack-alerts'
+      ecr_registry_path: 'tre-v2'
+    secrets:
+      AWS_OPEN_ID_CONNECT_ROLE_ARN: ${{ secrets.AWS_OPEN_ID_CONNECT_ROLE_ARN }}
+      AWS_CODEARTIFACT_REPOSITORY_NAME: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
+      AWS_CODEARTIFACT_REPOSITORY_DOMAIN: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
+      AWS_CODEARTIFACT_REPOSITORY_ACCOUNT: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # tre-fn-dlq-slack-alerts
+
+* [GitHub Actions](#github-actions)
+* [GitHub Action Secrets](#github-action-secrets)
+
+## GitHub Actions
+
+| Action | Description |
+| --- | --- |
+| [`.github/workflows/build-deploy-and-tag-ecr-image.yml`](.github/workflows/build-deploy-and-tag-ecr-image.yml) | Gets next git version tag<br>Builds and deploys Docker image to ECR<br>If successful, tags git with new version |
+
+## GitHub Action Secrets
+
+Secret for main AWS authentication (using OpenID Connect):
+
+| Name                         | Description                                          |
+| ---------------------------- | ---------------------------------------------------- |
+| AWS_OPEN_ID_CONNECT_ROLE_ARN | ARN of AWS role used to authenticate GitHub with AWS |
+
+Other secrets:
+
+| Name                                | Description                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| AWS_CODEARTIFACT_REPOSITORY_NAME    | Name of AWS CodeArtifact repository to log in to for additional packages |
+| AWS_CODEARTIFACT_REPOSITORY_DOMAIN  | Name of AWS CodeArtifact repository's domain                             |
+| AWS_CODEARTIFACT_REPOSITORY_ACCOUNT | The AWS account ID that owns the CodeArtifact                            |
+| AWS_REGION                          | The AWS region to use for CodeArtifact and ECR                           |

--- a/tre-dlq-slack-alerts/Dockerfile
+++ b/tre-dlq-slack-alerts/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.9
+ARG PIP_INDEX_URL
+
+# Copy function code
+COPY tre_dlq_slack_alerts.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+COPY requirements.txt ./requirements.txt
+RUN  yum -y update \
+     && yum clean all \
+     && pip install \
+       --requirement requirements.txt \
+       --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "tre_dlq_slack_alerts.lambda_handler" ]

--- a/tre-dlq-slack-alerts/requirements.txt
+++ b/tre-dlq-slack-alerts/requirements.txt
@@ -1,0 +1,1 @@
+# Used by common GitHub Action build workflow

--- a/tre-dlq-slack-alerts/tre_dlq_slack_alerts.py
+++ b/tre-dlq-slack-alerts/tre_dlq_slack_alerts.py
@@ -1,0 +1,36 @@
+import urllib3
+import json
+import os
+
+http = urllib3.PoolManager()
+slack_webhook_url = os.environ["SLACK_WEBHOOK_URL"]
+slack_channel = os.environ["SLACK_CHANNEL"]
+slack_username = os.environ["SLACK_USERNAME"]
+env = os.environ["ENV"]
+
+
+def lambda_handler(event, context):
+    """
+    Pushes dead letter notifications to slack, alongside the environment,
+    execution, and the triggering SQS dead letter event
+    """
+    print(event)
+    records = event["Records"][0]
+    attributes = records["attributes"]
+    body = json.loads(records["body"])
+    message = body["Message"]
+    sns_topic = body["TopicArn"].split(":")[-1]
+    source_queue = attributes["DeadLetterQueueSourceArn"].split(":")[-1]
+
+    final_message = f"*STATUS* :red_circle: \n  *Environment* `{env}` \n The following message was sent to `{source_queue}` _*SQS Queue*_ via `{sns_topic}` _*SNS Topic*_ which lambda failed to consume. \n *Message:*\n ```{message}``` \n"
+
+    msg = {
+        "channel": slack_channel,
+        "username": slack_username,
+        "text": final_message
+    }
+
+    print(final_message)
+    encoded_msg = json.dumps(msg, indent=2).encode("utf-8")
+    resp = http.request("POST", slack_webhook_url, body=encoded_msg)
+    print({"status_code": resp.status, "response": resp.data})


### PR DESCRIPTION
Migrated `lambda_functions/tre-dlq-slack-alerts` from repo da-transform-judgments-pipeline. Added GitHub Action workflow to build and deploy Docker image to ECR. Uses AWS CodeArtifact as upstream `pip` source if requirements.txt contains package definitions.